### PR TITLE
Update Cygwin-Build-for-Windows.md

### DIFF
--- a/_docs/Cygwin-Build-for-Windows.md
+++ b/_docs/Cygwin-Build-for-Windows.md
@@ -159,6 +159,12 @@ The CYGWIN `bash` shell is used for all steps on the command line. It is automat
    make install-strip
    ```
 
+1. Cleanup the installation. This removes also the intermediate big executables from the build folders.
+
+   ```bash
+   make clean
+   ```
+
 1. Add the `$SU2_HOME` and `$SU2_RUN` environment variables to `~/.bashrc` (and `source ~/.bashrc`)
 
    ```bash

--- a/_docs/Cygwin-Build-for-Windows.md
+++ b/_docs/Cygwin-Build-for-Windows.md
@@ -153,6 +153,12 @@ The CYGWIN `bash` shell is used for all steps on the command line. It is automat
    make install
    ```
 
+1. Reduce size of executables significantly (strip symbols, see also [CYGWIN FAQ 6.3](https://www.cygwin.com/faq.html). The SU2_CFD.exe is reduced from approx. 600MB to 15MB. Can be omitted if compiled with the -s option to gcc.
+
+   ```bash
+   make install-strip
+   ```
+
 1. Add the `$SU2_HOME` and `$SU2_RUN` environment variables to `~/.bashrc` (and `source ~/.bashrc`)
 
    ```bash

--- a/_docs/Cygwin-Build-for-Windows.md
+++ b/_docs/Cygwin-Build-for-Windows.md
@@ -132,6 +132,13 @@ The CYGWIN `bash` shell is used for all steps on the command line. It is automat
    ./bootstrap
    ```
 
+1. Set compiler flags (just to be sure not to use the debug option -g)
+   
+   ```bash
+   export CFLAGS='-O2'
+   export CXXFLAGS='-O2'
+   ```
+
 1. Create Makefiles:
 
    > NOTE: didn't yet get `tecio` working, therefore disabled with `--disable-tecio`<br>
@@ -154,7 +161,7 @@ The CYGWIN `bash` shell is used for all steps on the command line. It is automat
    ```
 
 1. Reduce size of executables significantly (strip symbols, see also [CYGWIN FAQ 6.3](https://www.cygwin.com/faq.html). The SU2_CFD.exe is reduced from approx. 600MB to 15MB. Can be omitted if compiled with the -s option to gcc.
-
+   > NOTE: This should **NOT** be necessary if compiler flags are set as shown in step 7
    ```bash
    make install-strip
    ```


### PR DESCRIPTION
Strip executable size.
From CYGWIN FAQ 6.3:
**By default, gcc compiles in all symbols. Just use the 'strip' program.  Or compile with the -s option to gcc.**