### PR TITLE
Fix name and typo in Laminar Flat Plate markdown

### DIFF
--- a/_tutorials/compressible_flow/Laminar_Flat_Plate.md
+++ b/_tutorials/compressible_flow/Laminar_Flat_Plate.md
@@ -6,7 +6,7 @@ for_version: 7.0.0
 revised_by: talbring
 revision_date: 2020-03-03
 revised_version: 7.0.2
-solver: Euler
+solver: Navier Stokes
 requires: SU2_CFD
 complexity: basic
 follows: 
@@ -86,7 +86,7 @@ SOLVER= NAVIER_STOKES
 KIND_TURB_MODEL= NONE
 ```
 
-To compute viscous flows, the Navier-Stokes governing equations are selected. The option `NAVIER_STOKES` implies that we wish to solve a laminar Naviwe-Stokes problem, and therefore, we must also set `KIND_TURB_MODEL= NONE`. For turbulent flows, SU2 solves the Reynolds-averaged Navier-Stokes equations by setting `SOLVER= RANS`, and SU2 currently contains implementations of the Spalart-Allmaras model and several variants (`SA`, `SA_NEG`, etc.) and the Shear Stress Transport (`SST`) model of Menter. If this were an inviscid flow problem, the user would enter `SOLVER = EULER` for the problem type. SU2 supports other governing equations, as well, and the user is invited to review the governing equations documentation page for a description of the possible options.
+To compute viscous flows, the Navier-Stokes governing equations are selected. The option `NAVIER_STOKES` implies that we wish to solve a laminar Navier-Stokes problem, and therefore, we must also set `KIND_TURB_MODEL= NONE`. For turbulent flows, SU2 solves the Reynolds-averaged Navier-Stokes equations by setting `SOLVER= RANS`, and SU2 currently contains implementations of the Spalart-Allmaras model and several variants (`SA`, `SA_NEG`, etc.) and the Shear Stress Transport (`SST`) model of Menter. If this were an inviscid flow problem, the user would enter `SOLVER = EULER` for the problem type. SU2 supports other governing equations, as well, and the user is invited to review the governing equations documentation page for a description of the possible options.
 
 Defining a no-slip boundary condition for viscous walls can be accomplished in one of two ways:
 


### PR DESCRIPTION
Fix a typo for Navier Stoke in line 89 of the markdown.  I also fix the solver for the problem description, it should be Navier Stoke and not Euler right? 