### PR TITLE
Fixed spelling/grammar mistakes in SU2-Linux-MacOS.md

### DIFF
--- a/_docs_v7/SU2-Linux-MacOS.md
+++ b/_docs_v7/SU2-Linux-MacOS.md
@@ -19,14 +19,14 @@ permalink: /docs_v7/SU2-Linux-MacOS/
 
 ### Setting Environment variables
 
-In order to use the executables from any directory without explicitely specifying the path to the executable you should set some environment variables. Either put the following lines to your `~/.bashrc` or `~/.bash_profile` to be permanent, or type the commands into the terminal for temporary use:
+In order to use the executables from any directory without explicitly specifying the path to the executable you should set some environment variables. Either add the following lines to your `~/.bashrc` or `~/.bash_profile` to be permanent, or type the commands into the terminal for temporary use:
 ```
 export SU2_RUN=<install_path>
 export PATH=$SU2_RUN:$PATH
 export PYTHONPATH=$SU2_RUN:$PYTHONPATH
 ```
 
-where `<install_path>` is the path to the SU2 binaries (i.e. the folder that contains `SU2_CFD` etc.). If you have build [SU2 from source](/docs_v7/Build-SU2-Linux-MacOS/), it will be the path that you specified with the `--prefix` option (default: `/usr/bin`). The `export` commands are also printed after a successful configuration using `meson.py`.
+where `<install_path>` is the path to the SU2 binaries (i.e. the folder that contains `SU2_CFD` etc.). If you have built [SU2 from source](/docs_v7/Build-SU2-Linux-MacOS/), it will be the path that you specified with the `--prefix` option (default: `/usr/bin`). The `export` commands are also printed after a successful configuration using `meson.py`.
 
 
 ### Optional: Install MPICH for parallel mode


### PR DESCRIPTION
Spelling mistakes in lines 22 and 29. Line 22: it should be either "add the following line to" or "put the following lines in".