### PR TITLE
Move fluid information to physical definition

### DIFF
--- a/_docs_v7/Physical-Definition.md
+++ b/_docs_v7/Physical-Definition.md
@@ -9,6 +9,7 @@ SU2 offers different ways of setting and computing this definition. This documen
 
 ---
 
+- [Fluid Model](#fluid-model)
 - [Reference Values](#reference-values)
 - [Free-Stream Definition (Compressible)](#free-stream-definition-compressible)
   - [Thermodynamic State](#thermodynamic-state)
@@ -27,6 +28,28 @@ SU2 offers different ways of setting and computing this definition. This documen
 - [Transition Models](#transition-models)
 
 ---
+
+## Fluid Model ##
+
+| Solver | Version |
+| --- | --- |
+| `EULER`, `NAVIER_STOKES`, `RANS`, `NEMO_EULER`, `NEMO_NAVIER_STOKES`, `INC_EULER`, `INC_NAVIER_STOKES`, `INC_RANS`, `FEM_EULER`, `FEM_NAVIER_STOKES` | 7.0.0 |
+
+For fluid simulations, a model defining the equation of state and thermodynamic properties of the fluid or mixture is required. This is selected using the `FLUID_MODEL` option in the config. Available fluid models in SU2 include:
+
+| Option Value | Description | 
+|---|---|
+|`STANDARD_AIR` | **Air model with ideal gas EOS** |
+|`IDEAL_GAS` | **Arbitrary fluid with ideal gas EOS** |
+|`VW_GAS` | **Arbitrary fluid with Vander-Waals EOS** |
+|`PR_GAS` | **Arbitrary fluid with Peng-Robinson EOS** |
+|`CONSTANT_DENSITY` | **Constant density** |
+|`INC_IDEAL_GAS` | **Incompressible fluid constant specific heat** |
+|`INC_IDEAL_GAS_POLY` | **Incompressible fluid polynomial specific heat** |
+|`SU2_NONEQ` | **SU2 nonequilibrium thermochemical library** |
+|`MUTATIONPP` | **Mutation++ nonequilibrium thermochemical library** |
+
+Some fluid models require the specification of additional parameters, with the full set of required options available in the configuration file template. 
 
 ## Reference Values ##
 

--- a/_docs_v7/Solver-Setup.md
+++ b/_docs_v7/Solver-Setup.md
@@ -8,7 +8,6 @@ This is a basic introduction on how to set up a simulation using SU2. We disting
 ---
 
 - [Defining the Problem](#defining-the-problem)
-  - [Specifying a Fluid Model](#specifying-a-fluid-model)
   - [Restarting the simulation](#restarting-the-simulation)
 - [Controlling the simulation](#controlling-the-simulation)
   - [Time-dependent Simulation](#time-dependent-simulation)
@@ -44,24 +43,6 @@ SU2 is capable of dealing with different kinds of physical problems. The kind of
 |`MULTIPHYSICS` | Multi-zone problem with different solvers in each zone | - |
 
 Every solver has its specific options and we refer to the tutorial cases for more information. However, the basic controls detailed in the remainder of this page are the same for all problems.
-
-## Specifying a Fluid Model ##
-
-For fluid simulations, a model defining the equation of state and thermodynamic properties of the fluid or mixture is required. This is selected using the `FLUID_MODEL` option in the config. Available fluid models in SU2 include:
-
-| Option Value | Description | 
-|---|---|
-|`STANDARD_AIR` | **Air model with ideal gas EOS** |
-|`IDEAL_GAS` | **Arbitrary fluid with ideal gas EOS** |
-|`VW_GAS` | **Arbitrary fluid with Vander-Waals EOS** |
-|`PR_GAS` | **Arbitrary fluid with Peng-Robinson EOS** |
-|`CONSTANT_DENSITY` | **Constant density** |
-|`INC_IDEAL_GAS` | **Incompressible ideal gas** |
-|`INC_IDEAL_GAS_POLY` | **Incompressible ideal gas** |
-|`SU2_NONEQ` | **SU2 nonequilibrium thermochemical library** |
-|`MUTATIONPP` | **Mutation++ nonequilibrium thermochemical library** |
-
-Some fluid models require the specification of additional parameters, with the full set of required options available in the configuration file template. 
 
 ## Restarting the simulation ##
 


### PR DESCRIPTION
Signed-off-by: jtneedels <jneedels@stanford.edu>

Moving fluid model description to phys def page. 
Fixing some descriptions based on input from Tom.