### PR TITLE
[WIP] Added tracy integration instructions

### DIFF
--- a/_data/docs_v7.yml
+++ b/_data/docs_v7.yml
@@ -58,7 +58,7 @@
   - Advanced-AD-Techniques
   - Container-Development
   - Writing-Unit-Tests
-
+  - Tracy-Integration
 - title: FAQ
   docs_v7:
   - FAQ

--- a/_docs_v7/Tracy-Integration.md
+++ b/_docs_v7/Tracy-Integration.md
@@ -50,23 +50,31 @@ This embeds the Tracy client into SU2 for profiling.
 
 ## Instrumenting SU2 Code
 
-To profile a function in SU2, add Tracy macros to the source code. Here’s an example:
+To profile a function in SU2, you must use the project's centralized wrapper macros. This approach ensures that profiling can be cleanly enabled or disabled at compile time without modifying the core logic.
 
-1. **Include the Tracy Header:**
-   - Add this at the top of the source file:
-     ```c++
-     #include <tracy/Tracy.hpp>
-     ```
+1.  **Include the SU2 Tracy Wrapper Header:**
+    -   Add an include directive for `tracy_structure.hpp` at the top of your C++ source file. The relative path will depend on the file's location. For example, for a file in `SU2_CFD/src/fluid/`:
+        ```cpp
+        #include "../../../Common/include/tracy_structure.hpp"
+        ```
+    -   **Important:** Do not include `<tracy/Tracy.hpp>` directly. The wrapper header manages the actual Tracy library.
 
-2. **Instrument the Function:**
-   - Use `ZoneScopedN` to mark the function for profiling:
-     ```c++
-     void MyFunction() {
-         ZoneScopedN("MyFunction");
-         // Function implementation
-     }
-     ```
-   - The `"MyFunction"` label identifies this section in the Tracy GUI.
+2.  **Instrument the Function with SU2 Macros:**
+    -   Use `SU2_ZONE_SCOPED_N("MyLabel")` to mark a function or scope with a custom name. This is the recommended macro for clarity.
+        ```cpp
+        void MyFunction() {
+            SU2_ZONE_SCOPED_N("MyFunction");
+            // Function implementation
+        }
+        ```
+    -   The label you provide (e.g., `"MyFunction"`) is what will appear in the Tracy profiler's timeline.
+    -   Alternatively, for a quick annotation, you can use `SU2_ZONE_SCOPED;`. This macro automatically uses the compiler-provided function name for the label.
+        ```cpp
+        void MyFunction() {
+            SU2_ZONE_SCOPED;
+            // Function implementation
+        }
+        ```
 
 ## Running the Profiler and Visualizing Data
 

--- a/_docs_v7/Tracy-Integration.md
+++ b/_docs_v7/Tracy-Integration.md
@@ -21,7 +21,7 @@ To compile SU2 with Tracy support, follow these steps:
 
 - Configure the build with Tracy enabled using Meson:
   ```bash
-  meson setup build -Dwith-mpi=disabled --buildtype=debugoptimized -Denable-tracy=true --prefix=<SU2_INSTALL_PATH>
+  ./meson.py setup build -Dwith-mpi=disabled --buildtype=debugoptimized -Denable-tracy=true --prefix=<SU2_INSTALL_PATH>
   ```
 - Build and install SU2:
   ```bash

--- a/_docs_v7/Tracy-Integration.md
+++ b/_docs_v7/Tracy-Integration.md
@@ -72,10 +72,12 @@ To profile a function in SU2, add Tracy macros to the source code. Here’s an e
 
 After compiling and instrumenting SU2, profile and visualize the data as follows:
 
-> For Ubuntu users, install additional dependencies required for the Tracy server with: 
+Note: For Ubuntu users, install additional dependencies required for the Tracy server with the following command.
+```bash
 sudo apt install libfreetype6-dev libcapstone-dev libdbus-1-dev \
 libxkbcommon-dev libwayland-dev wayland-protocols \
 libegl1-mesa-dev libglvnd-dev libgtk-3-dev
+```
 
 1. **Build the Tracy Server:**
    - Navigate to the Tracy directory: `cd <SU2_SOURCE_DIR>/subprojects/tracy`.

--- a/_docs_v7/Tracy-Integration.md
+++ b/_docs_v7/Tracy-Integration.md
@@ -72,14 +72,13 @@ To profile a function in SU2, add Tracy macros to the source code. Here’s an e
 
 After compiling and instrumenting SU2, profile and visualize the data as follows:
 
-Note: For Ubuntu users, install additional dependencies required for the Tracy server with the following command.
+1. **Build the Tracy Server:**
+Install additional dependencies required for the Tracy server.
 ```bash
 sudo apt install libfreetype6-dev libcapstone-dev libdbus-1-dev \
 libxkbcommon-dev libwayland-dev wayland-protocols \
 libegl1-mesa-dev libglvnd-dev libgtk-3-dev
 ```
-
-1. **Build the Tracy Server:**
    - Navigate to the Tracy directory: `cd <SU2_SOURCE_DIR>/subprojects/tracy`.
    - Build the profiler using CMake:
      ```bash

--- a/_docs_v7/Tracy-Integration.md
+++ b/_docs_v7/Tracy-Integration.md
@@ -1,0 +1,209 @@
+---
+title: Integrating Tracy Profiler with SU2
+permalink: /docs_v7/Tracy-Integration/
+---
+
+---
+
+- [Introduction](#introduction)
+- [Prerequisites](#prerequisites)
+- [Integrating Tracy with SU2](#integrating-tracy-with-su2)
+- [Setting Up the Tracy Server](#setting-up-the-tracy-server)
+- [Instrumenting SU2 Code](#instrumenting-su2-code)
+- [Using Tracy for Profiling](#using-tracy-for-profiling)
+- [Conclusion](#conclusion)
+
+---
+
+## Introduction
+
+Tracy is a high-performance, real-time profiler designed for C++ applications, offering nanosecond-resolution timing with minimal overhead. It is an excellent tool for profiling computationally intensive software like SU2, where traditional profilers such as Valgrind may introduce significant slowdowns. This guide provides step-by-step instructions for integrating Tracy with SU2, enabling users to analyze and optimize the performance of their CFD simulations effectively.
+
+## Prerequisites
+
+Before integrating Tracy with SU2, ensure the following software is installed:
+
+- **SU2 Source Code**: Version 8.2.0 or later.
+- **Meson Build System**: Version 0.61.1 or later.
+- **Git**: For retrieving the Tracy repository.
+- **C++ Compiler**: Such as GCC.
+- **CMake**: Required for building the Tracy profiler.
+
+For Ubuntu users, install additional dependencies required for the Tracy server with:
+
+```bash
+sudo apt install libfreetype6-dev libcapstone-dev libdbus-1-dev \
+libxkbcommon-dev libwayland-dev wayland-protocols \
+libegl1-mesa-dev libglvnd-dev libgtk-3-dev
+```
+
+## Integrating Tracy with SU2
+
+To embed the Tracy client into SU2, you need to modify the Meson build configuration. The client collects profiling data during runtime. Follow these steps:
+
+1. **Create a Wrap File for Tracy:**
+
+   - Navigate to the SU2 source directory: `cd <SU2_SOURCE_DIR>`.
+   - Create a file named `subprojects/tracy.wrap` with the following content:
+
+     ```ini
+     [wrap-git]
+     url = https://github.com/wolfpld/tracy.git
+     revision = master
+     depth = 1
+     ```
+
+2. **Update Meson Options:**
+
+   - Edit `meson_options.txt` (or `meson.options`) in `<SU2_SOURCE_DIR>` to include:
+
+     ```meson
+     option('tracy_enable', 
+            type: 'boolean', 
+            value: false, 
+            description: 'Enable Tracy profiling support')
+     ```
+
+3. **Modify the Main Meson Build File:**
+
+   - Open `meson.build` in `<SU2_SOURCE_DIR>` and add Tracy as a dependency when enabled:
+
+     ```meson
+     if get_option('tracy_enable')
+         tracy_dep = dependency('tracy', static: true)
+         su2_deps += tracy_dep
+         su2_cpp_args += '-DTRACY_ENABLE'
+         
+         if get_option('buildtype') != 'debugoptimized'
+             warning('For optimal Tracy profiling, use --buildtype=debugoptimized')
+         endif
+     endif
+     ```
+
+   - Update the `default_options` at the top of `meson.build`:
+
+     ```meson
+     default_options: ['buildtype=release',
+                       'warning_level=0',
+                       'c_std=c99',
+                       'cpp_std=c++11',
+                       'tracy_enable=false']
+     ```
+
+   - Update the Build Summary to display Tracy status by inserting `get_option('tracy_enable')` into the summary format string (adjust the index accordingly, e.g., `@14@`):
+
+     ```meson
+     Tracy Profiler: @14@
+     ```
+
+     And update the install instruction line:
+
+     ```meson
+     Use './ninja -C @15@ install' to compile and install SU2
+     ```
+
+4. **Build SU2 with Tracy:**
+
+   - Ensure Meson is updated:
+
+     ```bash
+     pip install --user --upgrade meson
+     ```
+
+   - Run the preconfigure script:
+
+     ```bash
+     ./preconfigure.py
+     ```
+
+   - Configure and build SU2:
+
+     ```bash
+     meson build_tracy -Dwith-mpi=disabled -Denable-pywrapper=true -Denable-mlpcpp=true --buildtype=debugoptimized -Dtracy_enable=true --prefix=<SU2_INSTALL_PATH>
+     ninja -C build_tracy install
+     ```
+
+   - Replace `<SU2_SOURCE_DIR>` with the path to your SU2 source code and `<SU2_INSTALL_PATH>` with your desired installation directory.
+
+This process integrates the Tracy client into SU2, enabling profiling capabilities.
+
+## Setting Up the Tracy Server
+
+The Tracy server is the graphical application that visualizes profiling data collected by the client. To set it up:
+
+1. **Build the Tracy Profiler:**
+
+   - Navigate to the Tracy directory: `cd <SU2_SOURCE_DIR>/subprojects/tracy`.
+   - Use CMake to build the profiler:
+
+     ```bash
+     cmake -B profiler/build -S profiler -DCMAKE_BUILD_TYPE=Release -DLEGACY=ON
+     cmake --build profiler/build --config Release --parallel
+     ```
+
+   - The `-DLEGACY=ON` flag enables X11 support, which may be necessary for some systems. Omit this flag if Wayland is preferred and supported.
+
+The Tracy server is now ready to display profiling data.
+
+## Instrumenting SU2 Code
+
+To collect meaningful profiling data, instrument the SU2 source code with Tracy macros. For example, to profile a specific function:
+
+1. **Include the Tracy Header:**
+
+   - Add the following at the top of the source file:
+
+     ```c++
+     #include <tracy/Tracy.hpp>
+     ```
+
+2. **Add Profiling Macros:**
+
+   - Instrument the function with `ZoneScopedN`:
+
+     ```c++
+     void MyFunction() {
+         ZoneScopedN("MyFunction");
+         // Function implementation
+     }
+     ```
+
+   - The `ZoneScopedN("name")` macro defines a profiling zone, labeled for identification in the Tracy GUI.
+
+Repeat this process for any functions or code sections you wish to profile.
+
+## Using Tracy for Profiling
+
+With the client integrated, the server built, and the code instrumented, you can profile SU2 simulations:
+
+1. **Launch the Tracy Profiler:**
+
+   - Navigate to the profiler build directory:
+
+     ```bash
+     cd <SU2_SOURCE_DIR>/subprojects/tracy/profiler/build
+     ```
+
+   - Run the profiler:
+
+     ```bash
+     ./tracy-profiler
+     ```
+
+   - In the GUI, click "Connect" to wait for a connection from SU2.
+
+2. **Execute the Instrumented SU2 Simulation:**
+
+   - In a separate terminal, navigate to your simulation directory and run:
+
+     ```bash
+     <SU2_INSTALL_PATH>/bin/SU2_CFD <your_config_file>.cfg
+     ```
+
+   - Replace `<SU2_INSTALL_PATH>` with your installation path and `<your_config_file>` with your configuration file.
+
+As the simulation runs, Tracy will display real-time profiling data, allowing you to analyze performance metrics and identify bottlenecks.
+
+## Conclusion
+
+Integrating Tracy with SU2 equips users with a powerful, low-overhead tool for profiling and optimizing CFD simulations. Its real-time visualization and precise timing capabilities make it ideal for performance analysis. For advanced features, troubleshooting, or additional details, consult the [Tracy documentation](https://github.com/wolfpld/tracy/releases/latest/download/tracy.pdf).

--- a/_docs_v7/Tracy-Integration.md
+++ b/_docs_v7/Tracy-Integration.md
@@ -19,32 +19,15 @@ Tracy is a high-performance, real-time profiler designed for C++ applications, o
 
 To compile SU2 with Tracy support, follow these steps:
 
-1. **Install Required Tools:**
-   - Tracy requires Meson version >=1.3.0, which is newer than the version provided by SU2. Install it manually:
-     ```bash
-     pip install --user --upgrade meson
-     ```
-   - Install Ninja manually, as it is required for the build process:
-     ```bash
-     sudo apt install ninja-build
-     ```
-
-2. **Run the Preconfigure Script:**
-   - Since the provided `meson.py` script is not used, run the preconfigure script to set up the build environment:
-     ```bash
-     ./preconfigure.py
-     ```
-
-3. **Configure and Build SU2:**
-   - Configure the build with Tracy enabled using Meson:
-     ```bash
-     meson setup build -Dwith-mpi=disabled --buildtype=debugoptimized -Denable_tracy=true --prefix=<SU2_INSTALL_PATH>
-     ```
-   - Build and install SU2:
-     ```bash
-     ninja -C build install
-     ```
-   - Replace `<SU2_INSTALL_PATH>` with your desired installation directory.
+- Configure the build with Tracy enabled using Meson:
+  ```bash
+  meson setup build -Dwith-mpi=disabled --buildtype=debugoptimized -Denable-tracy=true --prefix=<SU2_INSTALL_PATH>
+  ```
+- Build and install SU2:
+  ```bash
+  ./ninja -C build install
+  ```
+- Replace `<SU2_INSTALL_PATH>` with your desired installation directory.
 
 This embeds the Tracy client into SU2 for profiling.
 

--- a/_docs_v7/Tracy-Integration.md
+++ b/_docs_v7/Tracy-Integration.md
@@ -3,14 +3,10 @@ title: Integrating Tracy Profiler with SU2
 permalink: /docs_v7/Tracy-Integration/
 ---
 
----
-
 - [Introduction](#introduction)
-- [Prerequisites](#prerequisites)
-- [Integrating Tracy with SU2](#integrating-tracy-with-su2)
-- [Setting Up the Tracy Server](#setting-up-the-tracy-server)
+- [Compiling SU2 with Tracy](#compiling-su2-with-tracy)
 - [Instrumenting SU2 Code](#instrumenting-su2-code)
-- [Using Tracy for Profiling](#using-tracy-for-profiling)
+- [Running the Profiler and Visualizing Data](#running-the-profiler-and-visualizing-data)
 - [Conclusion](#conclusion)
 
 ---
@@ -19,190 +15,86 @@ permalink: /docs_v7/Tracy-Integration/
 
 Tracy is a high-performance, real-time profiler designed for C++ applications, offering nanosecond-resolution timing with minimal overhead. It is an excellent tool for profiling computationally intensive software like SU2, where traditional profilers such as Valgrind may introduce significant slowdowns. This guide provides step-by-step instructions for integrating Tracy with SU2, enabling users to analyze and optimize the performance of their CFD simulations effectively.
 
-## Prerequisites
+## Compiling SU2 with Tracy
 
-Before integrating Tracy with SU2, ensure the following software is installed:
+To compile SU2 with Tracy support, follow these steps:
 
-- **SU2 Source Code**: Version 8.2.0 or later.
-- **Meson Build System**: Version 0.61.1 or later.
-- **Git**: For retrieving the Tracy repository.
-- **C++ Compiler**: Such as GCC.
-- **CMake**: Required for building the Tracy profiler.
-
-For Ubuntu users, install additional dependencies required for the Tracy server with:
-
-```bash
-sudo apt install libfreetype6-dev libcapstone-dev libdbus-1-dev \
-libxkbcommon-dev libwayland-dev wayland-protocols \
-libegl1-mesa-dev libglvnd-dev libgtk-3-dev
-```
-
-## Integrating Tracy with SU2
-
-To embed the Tracy client into SU2, you need to modify the Meson build configuration. The client collects profiling data during runtime. Follow these steps:
-
-1. **Create a Wrap File for Tracy:**
-
-   - Navigate to the SU2 source directory: `cd <SU2_SOURCE_DIR>`.
-   - Create a file named `subprojects/tracy.wrap` with the following content:
-
-     ```ini
-     [wrap-git]
-     url = https://github.com/wolfpld/tracy.git
-     revision = master
-     depth = 1
-     ```
-
-2. **Update Meson Options:**
-
-   - Edit `meson_options.txt` (or `meson.options`) in `<SU2_SOURCE_DIR>` to include:
-
-     ```meson
-     option('tracy_enable', 
-            type: 'boolean', 
-            value: false, 
-            description: 'Enable Tracy profiling support')
-     ```
-
-3. **Modify the Main Meson Build File:**
-
-   - Open `meson.build` in `<SU2_SOURCE_DIR>` and add Tracy as a dependency when enabled:
-
-     ```meson
-     if get_option('tracy_enable')
-         tracy_dep = dependency('tracy', static: true)
-         su2_deps += tracy_dep
-         su2_cpp_args += '-DTRACY_ENABLE'
-         
-         if get_option('buildtype') != 'debugoptimized'
-             warning('For optimal Tracy profiling, use --buildtype=debugoptimized')
-         endif
-     endif
-     ```
-
-   - Update the `default_options` at the top of `meson.build`:
-
-     ```meson
-     default_options: ['buildtype=release',
-                       'warning_level=0',
-                       'c_std=c99',
-                       'cpp_std=c++11',
-                       'tracy_enable=false']
-     ```
-
-   - Update the Build Summary to display Tracy status by inserting `get_option('tracy_enable')` into the summary format string (adjust the index accordingly, e.g., `@14@`):
-
-     ```meson
-     Tracy Profiler: @14@
-     ```
-
-     And update the install instruction line:
-
-     ```meson
-     Use './ninja -C @15@ install' to compile and install SU2
-     ```
-
-4. **Build SU2 with Tracy:**
-
-   - Ensure Meson is updated:
-
+1. **Install Required Tools:**
+   - Tracy requires Meson version >=1.3.0, which is newer than the version provided by SU2. Install it manually:
      ```bash
      pip install --user --upgrade meson
      ```
+   - Install Ninja manually, as it is required for the build process:
+     ```bash
+     sudo apt install ninja-build
+     ```
 
-   - Run the preconfigure script:
-
+2. **Run the Preconfigure Script:**
+   - Since the provided `meson.py` script is not used, run the preconfigure script to set up the build environment:
      ```bash
      ./preconfigure.py
      ```
 
-   - Configure and build SU2:
-
+3. **Configure and Build SU2:**
+   - Configure the build with Tracy enabled using Meson:
      ```bash
-     meson build_tracy -Dwith-mpi=disabled -Denable-pywrapper=true -Denable-mlpcpp=true --buildtype=debugoptimized -Dtracy_enable=true --prefix=<SU2_INSTALL_PATH>
+     meson setup build_tracy -Dwith-mpi=disabled -Denable-mlpcpp=true --buildtype=debugoptimized -Dtracy_enable=true --prefix=<SU2_INSTALL_PATH>
+     ```
+   - Build and install SU2:
+     ```bash
      ninja -C build_tracy install
      ```
+   - Replace `<SU2_INSTALL_PATH>` with your desired installation directory.
 
-   - Replace `<SU2_SOURCE_DIR>` with the path to your SU2 source code and `<SU2_INSTALL_PATH>` with your desired installation directory.
-
-This process integrates the Tracy client into SU2, enabling profiling capabilities.
-
-## Setting Up the Tracy Server
-
-The Tracy server is the graphical application that visualizes profiling data collected by the client. To set it up:
-
-1. **Build the Tracy Profiler:**
-
-   - Navigate to the Tracy directory: `cd <SU2_SOURCE_DIR>/subprojects/tracy`.
-   - Use CMake to build the profiler:
-
-     ```bash
-     cmake -B profiler/build -S profiler -DCMAKE_BUILD_TYPE=Release -DLEGACY=ON
-     cmake --build profiler/build --config Release --parallel
-     ```
-
-   - The `-DLEGACY=ON` flag enables X11 support, which may be necessary for some systems. Omit this flag if Wayland is preferred and supported.
-
-The Tracy server is now ready to display profiling data.
+This embeds the Tracy client into SU2 for profiling.
 
 ## Instrumenting SU2 Code
 
-To collect meaningful profiling data, instrument the SU2 source code with Tracy macros. For example, to profile a specific function:
+To profile a function in SU2, add Tracy macros to the source code. Here’s an example:
 
 1. **Include the Tracy Header:**
-
-   - Add the following at the top of the source file:
-
+   - Add this at the top of the source file:
      ```c++
      #include <tracy/Tracy.hpp>
      ```
 
-2. **Add Profiling Macros:**
-
-   - Instrument the function with `ZoneScopedN`:
-
+2. **Instrument the Function:**
+   - Use `ZoneScopedN` to mark the function for profiling:
      ```c++
      void MyFunction() {
          ZoneScopedN("MyFunction");
          // Function implementation
      }
      ```
+   - The `"MyFunction"` label identifies this section in the Tracy GUI.
 
-   - The `ZoneScopedN("name")` macro defines a profiling zone, labeled for identification in the Tracy GUI.
+## Running the Profiler and Visualizing Data
 
-Repeat this process for any functions or code sections you wish to profile.
+After compiling and instrumenting SU2, profile and visualize the data as follows:
 
-## Using Tracy for Profiling
-
-With the client integrated, the server built, and the code instrumented, you can profile SU2 simulations:
-
-1. **Launch the Tracy Profiler:**
-
-   - Navigate to the profiler build directory:
-
+1. **Build the Tracy Server:**
+   - Navigate to the Tracy directory: `cd <SU2_SOURCE_DIR>/subprojects/tracy`.
+   - Build the profiler using CMake:
      ```bash
-     cd <SU2_SOURCE_DIR>/subprojects/tracy/profiler/build
+     cmake -B profiler/build -S profiler -DCMAKE_BUILD_TYPE=Release
+     cmake --build profiler/build --config Release --parallel
      ```
 
+2. **Launch the Tracy Profiler:**
    - Run the profiler:
-
      ```bash
-     ./tracy-profiler
+     ./profiler/build/tracy-profiler
      ```
+   - Click "Connect" in the GUI to wait for SU2.
 
-   - In the GUI, click "Connect" to wait for a connection from SU2.
-
-2. **Execute the Instrumented SU2 Simulation:**
-
-   - In a separate terminal, navigate to your simulation directory and run:
-
+3. **Run the SU2 Simulation:**
+   - In a separate terminal, execute your simulation:
      ```bash
      <SU2_INSTALL_PATH>/bin/SU2_CFD <your_config_file>.cfg
      ```
+   - Replace `<SU2_INSTALL_PATH>` and `<your_config_file>` with your installation path and configuration file.
 
-   - Replace `<SU2_INSTALL_PATH>` with your installation path and `<your_config_file>` with your configuration file.
-
-As the simulation runs, Tracy will display real-time profiling data, allowing you to analyze performance metrics and identify bottlenecks.
+The Tracy GUI will display real-time profiling data during the simulation.
 
 ## Conclusion
 

--- a/_docs_v7/Tracy-Integration.md
+++ b/_docs_v7/Tracy-Integration.md
@@ -38,11 +38,11 @@ To compile SU2 with Tracy support, follow these steps:
 3. **Configure and Build SU2:**
    - Configure the build with Tracy enabled using Meson:
      ```bash
-     meson setup build_tracy -Dwith-mpi=disabled -Denable-mlpcpp=true --buildtype=debugoptimized -Dtracy_enable=true --prefix=<SU2_INSTALL_PATH>
+     meson setup build -Dwith-mpi=disabled --buildtype=debugoptimized -Dtracy_enable=true --prefix=<SU2_INSTALL_PATH>
      ```
    - Build and install SU2:
      ```bash
-     ninja -C build_tracy install
+     ninja -C build install
      ```
    - Replace `<SU2_INSTALL_PATH>` with your desired installation directory.
 

--- a/_docs_v7/Tracy-Integration.md
+++ b/_docs_v7/Tracy-Integration.md
@@ -38,7 +38,7 @@ To compile SU2 with Tracy support, follow these steps:
 3. **Configure and Build SU2:**
    - Configure the build with Tracy enabled using Meson:
      ```bash
-     meson setup build -Dwith-mpi=disabled --buildtype=debugoptimized -Dtracy_enable=true --prefix=<SU2_INSTALL_PATH>
+     meson setup build -Dwith-mpi=disabled --buildtype=debugoptimized -Denable_tracy=true --prefix=<SU2_INSTALL_PATH>
      ```
    - Build and install SU2:
      ```bash

--- a/_docs_v7/Tracy-Integration.md
+++ b/_docs_v7/Tracy-Integration.md
@@ -73,6 +73,7 @@ To profile a function in SU2, add Tracy macros to the source code. Here’s an e
 After compiling and instrumenting SU2, profile and visualize the data as follows:
 
 1. **Build the Tracy Server:**
+
 Install additional dependencies required for the Tracy server.
 ```bash
 sudo apt install libfreetype6-dev libcapstone-dev libdbus-1-dev \

--- a/_docs_v7/Tracy-Integration.md
+++ b/_docs_v7/Tracy-Integration.md
@@ -72,6 +72,11 @@ To profile a function in SU2, add Tracy macros to the source code. Here’s an e
 
 After compiling and instrumenting SU2, profile and visualize the data as follows:
 
+> For Ubuntu users, install additional dependencies required for the Tracy server with: 
+sudo apt install libfreetype6-dev libcapstone-dev libdbus-1-dev \
+libxkbcommon-dev libwayland-dev wayland-protocols \
+libegl1-mesa-dev libglvnd-dev libgtk-3-dev
+
 1. **Build the Tracy Server:**
    - Navigate to the Tracy directory: `cd <SU2_SOURCE_DIR>/subprojects/tracy`.
    - Build the profiler using CMake:


### PR DESCRIPTION
This pull request integrates Tracy, a low-overhead, real-time profiler, into SU2. It adds a `tracy_enable` Meson build option, supports code instrumentation with Tracy macros, and includes setup instructions for the Tracy server, enabling developers to optimize CFD simulations efficiently.