### PR TITLE
Reformulating species diffusion description 

### DIFF
--- a/_docs_v7/Theory.md
+++ b/_docs_v7/Theory.md
@@ -264,11 +264,12 @@ $$S$$ is a generic source term, and the convective and viscous fluxes are
 
 $$\bar{F}^{c}(V) = \left\{\begin{array}{c} \rho Y_1 \bar{v} \\ ... \\\rho Y_{N-1} \, \bar{v} \end{array} \right\}$$
 
-$$\bar{F}^{v}(V,\nabla V) = \left\{\begin{array}{c} D \nabla Y_{1} \\ ... \\  D \nabla Y_{N-1} \end{array} \right\} $$
+$$\bar{F}^{v}(V,\nabla V) = \left\{\begin{array}{c} \rho D \nabla Y_{1} \\ ... \\  \rho D \nabla Y_{N-1} \end{array} \right\} $$
 
 with $$D$$ $$[m^2/s]$$ being the mass diffusion. 
+For turbulence modeling, the diffusion coefficient becomes:
 
-$$D = D_{lam} + \frac{\mu_T}{Sc_{T}}$$
+$$\rho D = \rho D_{lam} + \frac{\mu_T}{Sc_{T}}$$
 
 where $$\mu_T$$ is the eddy viscosity and $$Sc_{T}$$ $$[-]$$ the turbulent Schmidt number.
 


### PR DESCRIPTION
I think that density should be included in the species diffusion term, for being consistent with the equations written in the tutorial created by Evert and how it is implemented within the solver. Additional I added it in the turbulent modeling for clarity. 
Please let me know what you think @bigfooted 